### PR TITLE
Fix handling of native histogram encoding in OOO chunks

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -493,7 +493,7 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 	// those that overlap and stop when we know the rest don't.
 	slices.SortFunc(tmpChks, refLessByMinTimeAndMinRef)
 
-	mc := &mergedOOOChunks{}
+	mc := &mergedOOOChunks{encoding: chunkenc.EncXOR}
 	absoluteMax := int64(math.MinInt64)
 	for _, c := range tmpChks {
 		if c.meta.Ref != meta.Ref && (len(mc.chunks) == 0 || c.meta.MinTime > absoluteMax) {
@@ -530,6 +530,7 @@ func (s *memSeries) oooMergedChunk(meta chunks.Meta, cdm *chunks.ChunkDiskMapper
 			} else {
 				c.meta.Chunk = chk
 			}
+			mc.encoding = c.meta.Chunk.Encoding() // Update the oooMergedChunk encoding depending on the chunk's encoding type
 			mc.chunks = append(mc.chunks, c.meta)
 		}
 		if c.meta.MaxTime > absoluteMax {
@@ -545,28 +546,52 @@ var _ chunkenc.Chunk = &mergedOOOChunks{}
 // mergedOOOChunks holds the list of overlapping chunks. This struct satisfies
 // chunkenc.Chunk.
 type mergedOOOChunks struct {
-	chunks []chunks.Meta
+	chunks   []chunks.Meta
+	encoding chunkenc.Encoding
 }
 
 // Bytes is a very expensive method because its calling the iterator of all the
 // chunks in the mergedOOOChunk and building a new chunk with the samples.
 func (o mergedOOOChunks) Bytes() []byte {
-	xc := chunkenc.NewXORChunk()
+	var xc chunkenc.Chunk
+
+	switch o.encoding {
+	case chunkenc.EncXOR:
+		xc = chunkenc.NewXORChunk()
+	case chunkenc.EncHistogram:
+		xc = chunkenc.NewHistogramChunk()
+	case chunkenc.EncFloatHistogram:
+		xc = chunkenc.NewFloatHistogramChunk()
+	}
 	app, err := xc.Appender()
 	if err != nil {
 		panic(err)
 	}
 	it := o.Iterator(nil)
-	for it.Next() == chunkenc.ValFloat {
-		t, v := it.At()
-		app.Append(t, v)
+	for typ := it.Next(); typ != chunkenc.ValNone; typ = it.Next() {
+		switch typ {
+		case chunkenc.ValFloat:
+			t, v := it.At()
+			app.Append(t, v)
+		case chunkenc.ValHistogram:
+			prevHApp, _ := app.(*chunkenc.HistogramAppender)
+			t, v := it.AtHistogram()
+			// TODO(carrieedwards): check if logic for new chunk allocation is needed (see ToEncodedChunks method)
+			app.AppendHistogram(prevHApp, t, v, false)
+		case chunkenc.ValFloatHistogram:
+			prevHApp, _ := app.(*chunkenc.FloatHistogramAppender)
+			t, v := it.AtFloatHistogram()
+			// TODO(carrieedwards): check if logic for new chunk allocation is needed (see ToEncodedChunks method)
+			app.AppendFloatHistogram(prevHApp, t, v, false)
+		}
 	}
 
 	return xc.Bytes()
 }
 
 func (o mergedOOOChunks) Encoding() chunkenc.Encoding {
-	return chunkenc.EncXOR
+	// TODO(carrieedwards) Handle cases where chunks have different encoding types due to samples being of different types
+	return o.encoding
 }
 
 func (o mergedOOOChunks) Appender() (chunkenc.Appender, error) {
@@ -599,14 +624,36 @@ type boundedChunk struct {
 }
 
 func (b boundedChunk) Bytes() []byte {
-	xor := chunkenc.NewXORChunk()
-	a, _ := xor.Appender()
-	it := b.Iterator(nil)
-	for it.Next() == chunkenc.ValFloat {
-		t, v := it.At()
-		a.Append(t, v)
+	var xc chunkenc.Chunk
+
+	switch b.Encoding() {
+	case chunkenc.EncXOR:
+		xc = chunkenc.NewXORChunk()
+	case chunkenc.EncHistogram:
+		xc = chunkenc.NewHistogramChunk()
+	case chunkenc.EncFloatHistogram:
+		xc = chunkenc.NewFloatHistogramChunk()
 	}
-	return xor.Bytes()
+	app, _ := xc.Appender()
+	it := b.Iterator(nil)
+	for typ := it.Next(); typ != chunkenc.ValNone; typ = it.Next() {
+		switch typ {
+		case chunkenc.ValFloat:
+			t, v := it.At()
+			app.Append(t, v)
+		case chunkenc.ValHistogram:
+			prevHApp, _ := app.(*chunkenc.HistogramAppender)
+			t, v := it.AtHistogram()
+			// TODO(carrieedwards): check if logic for new chunk allocation is needed (see ToEncodedChunks method)
+			app.AppendHistogram(prevHApp, t, v, false)
+		case chunkenc.ValFloatHistogram:
+			prevHApp, _ := app.(*chunkenc.FloatHistogramAppender)
+			t, v := it.AtFloatHistogram()
+			// TODO(carrieedwards): check if logic for new chunk allocation is needed (see ToEncodedChunks method)
+			app.AppendFloatHistogram(prevHApp, t, v, false)
+		}
+	}
+	return xc.Bytes()
 }
 
 func (b boundedChunk) Iterator(iterator chunkenc.Iterator) chunkenc.Iterator {
@@ -632,7 +679,7 @@ type boundedIterator struct {
 // If there are samples within bounds it will advance one by one amongst them.
 // If there are no samples within bounds it will return false.
 func (b boundedIterator) Next() chunkenc.ValueType {
-	for b.Iterator.Next() == chunkenc.ValFloat {
+	for typ := b.Iterator.Next(); typ != chunkenc.ValNone; typ = b.Iterator.Next() {
 		t, _ := b.Iterator.At()
 		switch {
 		case t < b.minT:
@@ -640,7 +687,7 @@ func (b boundedIterator) Next() chunkenc.ValueType {
 		case t > b.maxT:
 			return chunkenc.ValNone
 		default:
-			return chunkenc.ValFloat
+			return typ
 		}
 	}
 	return chunkenc.ValNone
@@ -649,13 +696,13 @@ func (b boundedIterator) Next() chunkenc.ValueType {
 func (b boundedIterator) Seek(t int64) chunkenc.ValueType {
 	if t < b.minT {
 		// We must seek at least up to b.minT if it is asked for something before that.
-		val := b.Iterator.Seek(b.minT)
-		if !(val == chunkenc.ValFloat) {
+		valType := b.Iterator.Seek(b.minT)
+		if valType == chunkenc.ValNone {
 			return chunkenc.ValNone
 		}
 		t, _ := b.Iterator.At()
 		if t <= b.maxT {
-			return chunkenc.ValFloat
+			return valType
 		}
 	}
 	if t > b.maxT {

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -641,7 +641,7 @@ func (b boundedIterator) Seek(t int64) chunkenc.ValueType {
 		if valType == chunkenc.ValNone {
 			return chunkenc.ValNone
 		}
-		t, _ := b.Iterator.At()
+		t := b.Iterator.AtT()
 		if t <= b.maxT {
 			return valType
 		}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -15,6 +15,7 @@ package tsdb
 
 import (
 	"context"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"math"
 	"sync"
 
@@ -553,40 +554,8 @@ type mergedOOOChunks struct {
 // Bytes is a very expensive method because its calling the iterator of all the
 // chunks in the mergedOOOChunk and building a new chunk with the samples.
 func (o mergedOOOChunks) Bytes() []byte {
-	var xc chunkenc.Chunk
-
-	switch o.encoding {
-	case chunkenc.EncXOR:
-		xc = chunkenc.NewXORChunk()
-	case chunkenc.EncHistogram:
-		xc = chunkenc.NewHistogramChunk()
-	case chunkenc.EncFloatHistogram:
-		xc = chunkenc.NewFloatHistogramChunk()
-	}
-	app, err := xc.Appender()
-	if err != nil {
-		panic(err)
-	}
 	it := o.Iterator(nil)
-	for typ := it.Next(); typ != chunkenc.ValNone; typ = it.Next() {
-		switch typ {
-		case chunkenc.ValFloat:
-			t, v := it.At()
-			app.Append(t, v)
-		case chunkenc.ValHistogram:
-			prevHApp, _ := app.(*chunkenc.HistogramAppender)
-			t, v := it.AtHistogram()
-			// TODO(carrieedwards): check if logic for new chunk allocation is needed (see ToEncodedChunks method)
-			app.AppendHistogram(prevHApp, t, v, false)
-		case chunkenc.ValFloatHistogram:
-			prevHApp, _ := app.(*chunkenc.FloatHistogramAppender)
-			t, v := it.AtFloatHistogram()
-			// TODO(carrieedwards): check if logic for new chunk allocation is needed (see ToEncodedChunks method)
-			app.AppendFloatHistogram(prevHApp, t, v, false)
-		}
-	}
-
-	return xc.Bytes()
+	return tsdbutil.GetBytes(o.Encoding(), it)
 }
 
 func (o mergedOOOChunks) Encoding() chunkenc.Encoding {
@@ -624,36 +593,8 @@ type boundedChunk struct {
 }
 
 func (b boundedChunk) Bytes() []byte {
-	var xc chunkenc.Chunk
-
-	switch b.Encoding() {
-	case chunkenc.EncXOR:
-		xc = chunkenc.NewXORChunk()
-	case chunkenc.EncHistogram:
-		xc = chunkenc.NewHistogramChunk()
-	case chunkenc.EncFloatHistogram:
-		xc = chunkenc.NewFloatHistogramChunk()
-	}
-	app, _ := xc.Appender()
 	it := b.Iterator(nil)
-	for typ := it.Next(); typ != chunkenc.ValNone; typ = it.Next() {
-		switch typ {
-		case chunkenc.ValFloat:
-			t, v := it.At()
-			app.Append(t, v)
-		case chunkenc.ValHistogram:
-			prevHApp, _ := app.(*chunkenc.HistogramAppender)
-			t, v := it.AtHistogram()
-			// TODO(carrieedwards): check if logic for new chunk allocation is needed (see ToEncodedChunks method)
-			app.AppendHistogram(prevHApp, t, v, false)
-		case chunkenc.ValFloatHistogram:
-			prevHApp, _ := app.(*chunkenc.FloatHistogramAppender)
-			t, v := it.AtFloatHistogram()
-			// TODO(carrieedwards): check if logic for new chunk allocation is needed (see ToEncodedChunks method)
-			app.AppendFloatHistogram(prevHApp, t, v, false)
-		}
-	}
-	return xc.Bytes()
+	return tsdbutil.GetBytes(b.Encoding(), it)
 }
 
 func (b boundedChunk) Iterator(iterator chunkenc.Iterator) chunkenc.Iterator {
@@ -680,15 +621,7 @@ type boundedIterator struct {
 // If there are no samples within bounds it will return false.
 func (b boundedIterator) Next() chunkenc.ValueType {
 	for typ := b.Iterator.Next(); typ != chunkenc.ValNone; typ = b.Iterator.Next() {
-		var t int64
-		switch typ {
-		case chunkenc.ValFloat:
-			t, _ = b.Iterator.At()
-		case chunkenc.ValHistogram:
-			t, _ = b.Iterator.AtHistogram()
-		case chunkenc.ValFloatHistogram:
-			t, _ = b.Iterator.AtFloatHistogram()
-		}
+		t := b.Iterator.AtT()
 		switch {
 		case t < b.minT:
 			continue

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -680,7 +680,15 @@ type boundedIterator struct {
 // If there are no samples within bounds it will return false.
 func (b boundedIterator) Next() chunkenc.ValueType {
 	for typ := b.Iterator.Next(); typ != chunkenc.ValNone; typ = b.Iterator.Next() {
-		t, _ := b.Iterator.At()
+		var t int64
+		switch typ {
+		case chunkenc.ValFloat:
+			t, _ = b.Iterator.At()
+		case chunkenc.ValHistogram:
+			t, _ = b.Iterator.AtHistogram()
+		case chunkenc.ValFloatHistogram:
+			t, _ = b.Iterator.AtFloatHistogram()
+		}
 		switch {
 		case t < b.minT:
 			continue

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -15,10 +15,11 @@ package tsdb
 
 import (
 	"fmt"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -26,6 +27,61 @@ import (
 )
 
 func TestBoundedChunk(t *testing.T) {
+	scenarios := map[string]struct {
+		inputChunk chunkenc.Chunk
+		valueType  chunkenc.ValueType
+		appendFunc func(app chunkenc.Appender, ts int64, val float64)
+		chunkFunc  func(numSamples int) chunkenc.Chunk
+		sampleFunc func(ts int64) sample
+	}{
+		"float": {
+			valueType: chunkenc.ValFloat,
+			appendFunc: func(app chunkenc.Appender, ts int64, val float64) {
+				app.Append(ts, val)
+			},
+			chunkFunc: newTestChunk,
+			sampleFunc: func(ts int64) sample {
+				return sample{t: ts, f: float64(ts)}
+			},
+		},
+		"integer histogram": {
+			valueType: chunkenc.ValHistogram,
+			appendFunc: func(app chunkenc.Appender, ts int64, val float64) {
+				h := tsdbutil.GenerateTestHistogram(int(val))
+				prevHApp, _ := app.(*chunkenc.HistogramAppender)
+				app.AppendHistogram(prevHApp, ts, h, false)
+			},
+			chunkFunc: newTestHistogramChunk,
+			sampleFunc: func(ts int64) sample {
+				return sample{t: ts, h: tsdbutil.GenerateTestHistogram(int(ts))}
+			},
+		},
+		"float histogram": {
+			valueType: chunkenc.ValFloatHistogram,
+			appendFunc: func(app chunkenc.Appender, ts int64, val float64) {
+				fh := tsdbutil.GenerateTestFloatHistogram(int(val))
+				prevHApp, _ := app.(*chunkenc.FloatHistogramAppender)
+				app.AppendFloatHistogram(prevHApp, ts, fh, false)
+			},
+			chunkFunc: newTestFloatHistogramChunk,
+			sampleFunc: func(ts int64) sample {
+				return sample{t: ts, fh: tsdbutil.GenerateTestFloatHistogram(int(ts))}
+			},
+		},
+	}
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			testBoundedChunk(t, scenario.valueType, scenario.appendFunc, scenario.chunkFunc, scenario.sampleFunc)
+		})
+	}
+}
+
+func testBoundedChunk(t *testing.T,
+	valueType chunkenc.ValueType,
+	appendFunc func(app chunkenc.Appender, ts int64, val float64),
+	chunkFunc func(numSamples int) chunkenc.Chunk,
+	sampleFunc func(ts int64) sample,
+) {
 	tests := []struct {
 		name           string
 		inputChunk     chunkenc.Chunk
@@ -33,94 +89,52 @@ func TestBoundedChunk(t *testing.T) {
 		inputMaxT      int64
 		initialSeek    int64
 		seekIsASuccess bool
-		expSamples     []sample
 	}{
 		{
 			name:       "if there are no samples it returns nothing",
-			inputChunk: newTestChunk(0),
-			expSamples: nil,
+			inputChunk: chunkFunc(0),
 		},
 		{
 			name:       "bounds represent a single sample",
-			inputChunk: newTestChunk(10),
-			expSamples: []sample{
-				{0, 0, nil, nil},
-			},
+			inputChunk: chunkFunc(10),
 		},
 		{
 			name:       "if there are bounds set only samples within them are returned",
-			inputChunk: newTestChunk(10),
+			inputChunk: chunkFunc(10),
 			inputMinT:  1,
 			inputMaxT:  8,
-			expSamples: []sample{
-				{1, 1, nil, nil},
-				{2, 2, nil, nil},
-				{3, 3, nil, nil},
-				{4, 4, nil, nil},
-				{5, 5, nil, nil},
-				{6, 6, nil, nil},
-				{7, 7, nil, nil},
-				{8, 8, nil, nil},
-			},
 		},
 		{
 			name:       "if bounds set and only maxt is less than actual maxt",
-			inputChunk: newTestChunk(10),
+			inputChunk: chunkFunc(10),
 			inputMinT:  0,
 			inputMaxT:  5,
-			expSamples: []sample{
-				{0, 0, nil, nil},
-				{1, 1, nil, nil},
-				{2, 2, nil, nil},
-				{3, 3, nil, nil},
-				{4, 4, nil, nil},
-				{5, 5, nil, nil},
-			},
 		},
 		{
 			name:       "if bounds set and only mint is more than actual mint",
-			inputChunk: newTestChunk(10),
+			inputChunk: chunkFunc(10),
 			inputMinT:  5,
 			inputMaxT:  9,
-			expSamples: []sample{
-				{5, 5, nil, nil},
-				{6, 6, nil, nil},
-				{7, 7, nil, nil},
-				{8, 8, nil, nil},
-				{9, 9, nil, nil},
-			},
 		},
 		{
 			name:           "if there are bounds set with seek before mint",
-			inputChunk:     newTestChunk(10),
+			inputChunk:     chunkFunc(10),
 			inputMinT:      3,
 			inputMaxT:      7,
 			initialSeek:    1,
 			seekIsASuccess: true,
-			expSamples: []sample{
-				{3, 3, nil, nil},
-				{4, 4, nil, nil},
-				{5, 5, nil, nil},
-				{6, 6, nil, nil},
-				{7, 7, nil, nil},
-			},
 		},
 		{
 			name:           "if there are bounds set with seek between mint and maxt",
-			inputChunk:     newTestChunk(10),
+			inputChunk:     chunkFunc(10),
 			inputMinT:      3,
 			inputMaxT:      7,
 			initialSeek:    5,
 			seekIsASuccess: true,
-			expSamples: []sample{
-				{5, 5, nil, nil},
-				{6, 6, nil, nil},
-				{7, 7, nil, nil},
-			},
 		},
 		{
 			name:           "if there are bounds set with seek after maxt",
-			inputChunk:     newTestChunk(10),
+			inputChunk:     chunkFunc(10),
 			inputMinT:      3,
 			inputMaxT:      7,
 			initialSeek:    8,
@@ -132,12 +146,24 @@ func TestBoundedChunk(t *testing.T) {
 			chunk := boundedChunk{tc.inputChunk, tc.inputMinT, tc.inputMaxT}
 
 			// Testing Bytes()
-			expChunk := chunkenc.NewXORChunk()
+			var expChunk chunkenc.Chunk
+			var expSamples []sample
+
+			switch tc.inputChunk.Encoding() {
+			case chunkenc.EncXOR:
+				expChunk = chunkenc.NewXORChunk()
+			case chunkenc.EncHistogram:
+				expChunk = chunkenc.NewHistogramChunk()
+			case chunkenc.EncFloatHistogram:
+				expChunk = chunkenc.NewFloatHistogramChunk()
+			}
+
 			if tc.inputChunk.NumSamples() > 0 {
 				app, err := expChunk.Appender()
 				require.NoError(t, err)
 				for ts := tc.inputMinT; ts <= tc.inputMaxT; ts++ {
-					app.Append(ts, float64(ts))
+					appendFunc(app, ts, float64(ts))
+					expSamples = append(expSamples, sampleFunc(ts))
 				}
 			}
 			require.Equal(t, expChunk.Bytes(), chunk.Bytes())
@@ -148,17 +174,39 @@ func TestBoundedChunk(t *testing.T) {
 			if tc.initialSeek != 0 {
 				// Testing Seek()
 				val := it.Seek(tc.initialSeek)
-				require.Equal(t, tc.seekIsASuccess, val == chunkenc.ValFloat)
-				if val == chunkenc.ValFloat {
-					t, v := it.At()
-					samples = append(samples, sample{t, v, nil, nil})
+				require.Equal(t, tc.seekIsASuccess, val == valueType)
+				if val == valueType {
+					switch valueType {
+					case chunkenc.ValFloat:
+						t, v := it.At()
+						samples = append(samples, sample{t, v, nil, nil})
+					case chunkenc.ValHistogram:
+						t, v := it.AtHistogram()
+						v.CounterResetHint = histogram.UnknownCounterReset
+						samples = append(samples, sample{t, 0, v, nil})
+					case chunkenc.ValFloatHistogram:
+						t, v := it.AtFloatHistogram()
+						v.CounterResetHint = histogram.UnknownCounterReset
+						samples = append(samples, sample{t, 0, nil, v})
+					}
 				}
 			}
 
 			// Testing Next()
-			for it.Next() == chunkenc.ValFloat {
-				t, v := it.At()
-				samples = append(samples, sample{t, v, nil, nil})
+			for it.Next() == valueType {
+				switch valueType {
+				case chunkenc.ValFloat:
+					t, v := it.At()
+					samples = append(samples, sample{t, v, nil, nil})
+				case chunkenc.ValHistogram:
+					t, v := it.AtHistogram()
+					v.CounterResetHint = histogram.UnknownCounterReset
+					samples = append(samples, sample{t, 0, v, nil})
+				case chunkenc.ValFloatHistogram:
+					t, v := it.AtFloatHistogram()
+					v.CounterResetHint = histogram.UnknownCounterReset
+					samples = append(samples, sample{t, 0, nil, v})
+				}
 			}
 
 			// it.Next() should keep returning no  value.
@@ -166,7 +214,7 @@ func TestBoundedChunk(t *testing.T) {
 				require.True(t, it.Next() == chunkenc.ValNone)
 			}
 
-			require.Equal(t, tc.expSamples, samples)
+			require.Equal(t, expSamples, samples)
 		})
 	}
 }
@@ -178,6 +226,116 @@ func newTestChunk(numSamples int) chunkenc.Chunk {
 		a.Append(int64(i), float64(i))
 	}
 	return xor
+}
+
+func newTestHistogramChunk(numSamples int) chunkenc.Chunk {
+	xc := chunkenc.NewHistogramChunk()
+	a, _ := xc.Appender()
+	for i := 0; i < numSamples; i++ {
+		prevHApp, _ := a.(*chunkenc.HistogramAppender)
+		h := tsdbutil.GenerateTestHistogram(i)
+		a.AppendHistogram(prevHApp, int64(i), h, false)
+	}
+	return xc
+}
+
+func newTestFloatHistogramChunk(numSamples int) chunkenc.Chunk {
+	xc := chunkenc.NewFloatHistogramChunk()
+	a, _ := xc.Appender()
+	for i := 0; i < numSamples; i++ {
+		prevHApp, _ := a.(*chunkenc.FloatHistogramAppender)
+		fh := tsdbutil.GenerateTestFloatHistogram(i)
+		a.AppendFloatHistogram(prevHApp, int64(i), fh, false)
+	}
+	return xc
+}
+
+func TestMergedOOOChunks(t *testing.T) {
+	scenarios := map[string]struct {
+		inputChunk chunkenc.Chunk
+		valueType  chunkenc.ValueType
+		appendFunc func(app chunkenc.Appender, ts int64, val float64)
+		chunkFunc  func(numSamples int) chunkenc.Chunk
+		sampleFunc func(ts int64) sample
+	}{
+		"float": {
+			valueType: chunkenc.ValFloat,
+			appendFunc: func(app chunkenc.Appender, ts int64, val float64) {
+				app.Append(ts, val)
+			},
+			chunkFunc: newTestChunk,
+			sampleFunc: func(ts int64) sample {
+				return sample{t: ts, f: float64(ts)}
+			},
+		},
+		"integer histogram": {
+			valueType: chunkenc.ValHistogram,
+			appendFunc: func(app chunkenc.Appender, ts int64, val float64) {
+				h := tsdbutil.GenerateTestHistogram(int(val))
+				prevHApp, _ := app.(*chunkenc.HistogramAppender)
+				app.AppendHistogram(prevHApp, ts, h, false)
+			},
+			chunkFunc: newTestHistogramChunk,
+			sampleFunc: func(ts int64) sample {
+				return sample{t: ts, h: tsdbutil.GenerateTestHistogram(int(ts))}
+			},
+		},
+		"float histogram": {
+			valueType: chunkenc.ValFloatHistogram,
+			appendFunc: func(app chunkenc.Appender, ts int64, val float64) {
+				fh := tsdbutil.GenerateTestFloatHistogram(int(val))
+				prevHApp, _ := app.(*chunkenc.FloatHistogramAppender)
+				app.AppendFloatHistogram(prevHApp, ts, fh, false)
+			},
+			chunkFunc: newTestFloatHistogramChunk,
+			sampleFunc: func(ts int64) sample {
+				return sample{t: ts, fh: tsdbutil.GenerateTestFloatHistogram(int(ts))}
+			},
+		},
+	}
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			testMergedOOOChunks(t, scenario.valueType, scenario.appendFunc, scenario.chunkFunc, scenario.sampleFunc)
+		})
+	}
+}
+
+func testMergedOOOChunks(t *testing.T,
+	valueType chunkenc.ValueType,
+	appendFunc func(app chunkenc.Appender, ts int64, val float64),
+	chunkFunc func(numSamples int) chunkenc.Chunk,
+	sampleFunc func(ts int64) sample,
+) {
+	encoding := chunkenc.EncXOR
+	// Testing Bytes()
+	var expChunk chunkenc.Chunk
+	var expSamples []sample
+	var chunks []chunks.Meta
+
+	switch encoding {
+	case chunkenc.EncXOR:
+		expChunk = chunkenc.NewXORChunk()
+	case chunkenc.EncHistogram:
+		expChunk = chunkenc.NewHistogramChunk()
+	case chunkenc.EncFloatHistogram:
+		expChunk = chunkenc.NewFloatHistogramChunk()
+	}
+
+	app, err := expChunk.Appender()
+	require.NoError(t, err)
+	minT := 1
+	maxT := 5
+	for ts := minT; ts <= maxT; ts++ {
+		appendFunc(app, int64(ts), float64(ts))
+		smpl := sampleFunc(int64(ts))
+		chunks = append(chunks, assureChunkFromSamples(t, []tsdbutil.Sample{smpl}))
+		expSamples = append(expSamples, smpl)
+	}
+
+	mc := &mergedOOOChunks{encoding: encoding}
+	mc.chunks = append(mc.chunks, chunks...)
+
+	require.Equal(t, expChunk.Bytes(), mc.Bytes())
 }
 
 // TestMemSeries_chunk runs a series of tests on memSeries.chunk() calls.


### PR DESCRIPTION
This PR fixes the handling of integer and float native histograms in the mergedOOOChunks and boundedChunk data structures. Previously, the chunkenc.XOR encoding type was hard-coded, so native histograms would be improperly encoded. This caused issues when querying for native histogram data.
